### PR TITLE
fix: replace #config with #nitro

### DIFF
--- a/src/runtime/server/api/session.ts
+++ b/src/runtime/server/api/session.ts
@@ -2,9 +2,10 @@ import type { IncomingMessage, ServerResponse } from 'http'
 import { useBody, setCookie } from 'h3'
 import { useRuntimeConfig } from '#nitro'
 
+const config = useRuntimeConfig()
+
 export default async (req: IncomingMessage, res: ServerResponse) => {
   const body = await useBody(req)
-  const config = useRuntimeConfig()
   const cookieOptions = config.supabase.cookies
 
   const { event, session } = body

--- a/src/runtime/server/api/session.ts
+++ b/src/runtime/server/api/session.ts
@@ -1,9 +1,10 @@
 import type { IncomingMessage, ServerResponse } from 'http'
 import { useBody, setCookie } from 'h3'
-import config from '#config'
+import { useRuntimeConfig } from '#nitro'
 
 export default async (req: IncomingMessage, res: ServerResponse) => {
   const body = await useBody(req)
+  const config = useRuntimeConfig()
   const cookieOptions = config.supabase.cookies
 
   const { event, session } = body


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
I replaced `import config from '#config'` with the new `import { useRuntimeConfig } from '#nitro'` due to migration to nitropack by Nuxt 3.

<!--- Why is this change required? What problem does it solve? -->
During the migration to nitropack in Nuxt 3, the runtime config can be directly imported from virtual `#nitro` not `#config`.

<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Resolves: #22 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
