### PR TITLE
feat(server): propose services to use in server routes

### DIFF
--- a/docs/pages/2.usage.md
+++ b/docs/pages/2.usage.md
@@ -3,9 +3,11 @@ title: Usage
 description: Learn how to use the Supabase module in your Nuxt 3 application.
 ---
 
-This module exposes composables that are [auto-imported](https://v3.nuxtjs.org/docs/directory-structure/composables) by Nuxt 3.
+## Vue composables
 
-## `useSupabaseClient`
+This module provides composables to use inside vour `vue` files. Those exposed composables are [auto-imported](https://v3.nuxtjs.org/docs/directory-structure/composables) by Nuxt 3.
+
+### `useSupabaseClient`
 
 This composable is using [supabase-js](https://github.com/supabase/supabase-js/) under the hood, it gives acces to the [Supabase client](https://supabase.com/docs/reference/javascript/supabase-client).
 
@@ -17,7 +19,9 @@ const client = useSupabaseClient()
 </script>
 ```
 
-### `Auth`
+<br>
+
+ 1. Authentification
 
 All authentification methods are available on [Supabase Auth](https://supabase.com/docs/reference/javascript/auth-signup) Documentation.
 
@@ -54,7 +58,9 @@ Thanks to the [Nuxt plugin](https://v3.nuxtjs.org/docs/directory-structure/plugi
 
 Take a look at the [advanced](/advanced) section to learn how to leverage Nuxt middleware to protect your routes for unauthenticated users.
 
-### `Database`
+<br>
+
+ 2. Database Request
 
 Please check [Supabase](https://supabase.com/docs/reference/javascript/select) documentation to fully use the power of Supabase client.
 
@@ -73,7 +79,7 @@ const { data: restaurant } } = await useAsyncData('restaurant', async () => {
 </script>
 ```
 
-## `useSupabaseUser`
+### `useSupabaseUser`
 
 Once logged in, you can access your user everywhere:
 
@@ -84,3 +90,56 @@ const user = useSupabaseUser()
 ```
 
 > Learn how to protect your routes by writing your own [auth middleware composable](/advanced#auth-middleware).
+
+## Server routes services
+
+> This section assumes you're familiar with [Nitro](https://v3.nuxtjs.org/guide/concepts/server-engine#standalone-server), the server engine powered by Nuxt.
+
+In order to provide utilities similar to `vue` composables (see first section) in [server routes](https://v3.nuxtjs.org/guide/features/server-routes/), this module exposes services providing the same functionnalities.
+
+### `serverSupabaseClient`
+
+This function is working similary as the [useSupabaseClient](/usage#usesupabaseclient) composable but can be used in server routes.
+
+Define your server route and just use the `serverSupabaseClient` like:
+
+```ts [server/api/librairies.ts]
+export default eventHandler(async (event) => {
+  const client = serverSupabaseClient(event)
+
+  const { data } = client.from('librairies').select('name')
+
+  return { librairies: data }
+})
+```
+
+Then call your api route from any vue file:
+
+```ts [pages/index.vue]
+const callSupabaseClientInServerRoute = async () => {
+  const { librairies } = await $fetch('/api/librairies')
+}
+```
+
+### `serverSupabaseUser`
+
+This function is working similary as the [useSupabaseUser](/usage#usesupabaseuser) composable but can be used in server routes.
+
+Define your server route and just use the `serverSupabaseUser` like:
+
+```ts [server/api/me.ts]
+export default eventHandler(async (event) => {
+  const user = await serverSupabaseUser(event)
+
+  return { user }
+})
+```
+
+Then call your api route from any vue file:
+
+
+```ts [pages/index.vue]
+const getSupabaseUserFromServerRoute = async () => {
+  const { user } = await $fetch('/api/me')
+}
+```

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dist"
   ],
   "scripts": {
+    "dev": "nuxi dev playground",
     "build": "nuxt-module-build",
     "lint": "eslint --ext .js,.ts,.vue .",
     "prepack": "yarn build",

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,8 +1,23 @@
 <script setup lang="ts">
+
+const data = ref(null)
+
+const callServerClient = async () => {
+  data.value = await $fetch('/api/test')
+}
+
 </script>
 
 <template>
   <div>
-    Supabase module playground!
+    <h1>
+      Supabase module playground!
+    </h1>
+    <button @click="callServerClient">
+      Get data from server routes
+    </button>
+    <pre>
+      {{ data }}
+    </pre>
   </div>
 </template>

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <div>
+    Supabase module playground!
+  </div>
+</template>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,0 +1,8 @@
+import { defineNuxtConfig } from 'nuxt'
+import supabaseModule from '..'
+
+export default defineNuxtConfig({
+  modules: [
+    supabaseModule
+  ]
+})

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "name": "supabase-playground"
+}

--- a/playground/server/api/test.ts
+++ b/playground/server/api/test.ts
@@ -1,0 +1,9 @@
+import { serverSupabaseClient } from '../../../src/runtime/server/services/serverSupabaseClient'
+
+export default eventHandler(async (event) => {
+  const client = serverSupabaseClient(event)
+
+  const { data } = await client.from('pushupers').select()
+
+  return data
+})

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath } from 'url'
 import { defu } from 'defu'
-import { resolve } from 'pathe'
-import { defineNuxtModule, addPlugin, addServerMiddleware, extendViteConfig } from '@nuxt/kit'
+import { defineNuxtModule, addPlugin, addServerMiddleware, extendViteConfig, resolveModule, createResolver } from '@nuxt/kit'
 import { CookieOptions, SupabaseClientOptions } from '@supabase/supabase-js'
 
 export interface ModuleOptions {
@@ -67,6 +66,9 @@ export default defineNuxtModule<ModuleOptions>({
     }
   },
   setup (options, nuxt) {
+    const { resolve } = createResolver(import.meta.url)
+    const resolveRuntimeModule = (path: string) => resolveModule(path, { paths: resolve('./runtime') })
+
     // Make sure url and key are set
     if (!options.url) {
       throw new Error('Missing `SUPABASE_URL` in `.env`')
@@ -107,8 +109,8 @@ export default defineNuxtModule<ModuleOptions>({
       nitroConfig.autoImport = nitroConfig.autoImport || {}
       nitroConfig.autoImport.imports = nitroConfig.autoImport.imports || []
       nitroConfig.autoImport.imports.push(
-        { name: 'serverSupabaseClient', from: resolve(runtimeDir, 'server', 'services', 'serverSupabaseClient') },
-        { name: 'serverSupabaseUser', from: resolve(runtimeDir, 'server', 'services', 'serverSupabaseUser') }
+        { name: 'serverSupabaseClient', from: resolveRuntimeModule('./server/services/serverSupabaseClient') },
+        { name: 'serverSupabaseUser', from: resolveRuntimeModule('./server/services/serverSupabaseUser') }
       )
     })
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -97,9 +97,19 @@ export default defineNuxtModule<ModuleOptions>({
       handler: resolve(runtimeDir, 'server/api/session')
     })
 
-    // Add supabase composables
+    // Add vue composables (client side context)
     nuxt.hook('autoImports:dirs', (dirs) => {
       dirs.push(resolve(runtimeDir, 'composables'))
+    })
+
+    // Add nitro services (server side context)
+    nuxt.hook('nitro:config', (nitroConfig) => {
+      nitroConfig.autoImport = nitroConfig.autoImport || {}
+      nitroConfig.autoImport.imports = nitroConfig.autoImport.imports || []
+      nitroConfig.autoImport.imports.push(
+        { name: 'serverSupabaseClient', from: resolve(runtimeDir, 'server', 'services', 'serverSupabaseClient') },
+        { name: 'serverSupabaseUser', from: resolve(runtimeDir, 'server', 'services', 'serverSupabaseUser') }
+      )
     })
 
     // Optimize cross-fetch

--- a/src/runtime/composables/useSupabaseClient.ts
+++ b/src/runtime/composables/useSupabaseClient.ts
@@ -1,7 +1,6 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js'
-// import { useCookie } from 'h3'
-import { useRuntimeConfig, useNuxtApp } from '#app'
 import { useSupabaseToken } from './useSupabaseToken'
+import { useRuntimeConfig, useNuxtApp } from '#imports'
 
 export const useSupabaseClient = (): SupabaseClient => {
   const nuxtApp = useNuxtApp()

--- a/src/runtime/composables/useSupabaseToken.ts
+++ b/src/runtime/composables/useSupabaseToken.ts
@@ -1,4 +1,4 @@
-import { useCookie, useRuntimeConfig } from '#app'
+import { useCookie, useRuntimeConfig } from '#imports'
 
 export const useSupabaseToken = () => {
   const { supabase: { cookies: cookieOptions } } = useRuntimeConfig().public

--- a/src/runtime/composables/useSupabaseUser.ts
+++ b/src/runtime/composables/useSupabaseUser.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
 import { User } from '@supabase/supabase-js'
-import { useState } from '#app'
+import { useState } from '#imports'
 
 export const useSupabaseUser = (): Ref<User | null> => useState<User | null>('supabase_user')

--- a/src/runtime/plugins/supabase.client.ts
+++ b/src/runtime/plugins/supabase.client.ts
@@ -1,8 +1,8 @@
 import { AuthChangeEvent, Session } from '@supabase/supabase-js'
-import { defineNuxtPlugin, NuxtApp } from '#app'
 import { useSupabaseClient } from '../composables/useSupabaseClient'
 import { useSupabaseUser } from '../composables/useSupabaseUser'
 import { useSupabaseToken } from '../composables/useSupabaseToken'
+import { defineNuxtPlugin, NuxtApp } from '#imports'
 
 export default defineNuxtPlugin(async (nuxtApp: NuxtApp) => {
   const user = useSupabaseUser()

--- a/src/runtime/plugins/supabase.server.ts
+++ b/src/runtime/plugins/supabase.server.ts
@@ -1,8 +1,7 @@
-// import { useCookie } from 'h3'
-import { defineNuxtPlugin } from '#app'
 import { useSupabaseUser } from '../composables/useSupabaseUser'
 import { useSupabaseClient } from '../composables/useSupabaseClient'
 import { useSupabaseToken } from '../composables/useSupabaseToken'
+import { defineNuxtPlugin } from '#imports'
 
 // Set subabase user on server side
 export default defineNuxtPlugin(async () => {

--- a/src/runtime/server/services/serverSupabaseClient.ts
+++ b/src/runtime/server/services/serverSupabaseClient.ts
@@ -1,0 +1,20 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
+import { CompatibilityEvent, useCookie } from 'h3'
+import { useRuntimeConfig } from '#imports'
+
+export const serverSupabaseClient = (event: CompatibilityEvent): SupabaseClient => {
+  const { supabase: { url, key, options, cookies: cookieOptions } } = useRuntimeConfig().public
+
+  // No need to recreate client if exists in request context
+  if (!event.context._supabaseClient) {
+    const supabaseClient = createClient(url, key, options)
+    const token = useCookie(event, `${cookieOptions.name}-access-token`)
+
+    supabaseClient.auth.setAuth(token)
+
+    event.context._supabaseClient = supabaseClient
+    event.context._token = token
+  }
+
+  return event.context._supabaseClient
+}

--- a/src/runtime/server/services/serverSupabaseUser.ts
+++ b/src/runtime/server/services/serverSupabaseUser.ts
@@ -1,0 +1,17 @@
+import { User } from '@supabase/supabase-js'
+import type { CompatibilityEvent } from 'h3'
+import { serverSupabaseClient } from '../services/serverSupabaseClient'
+
+export const serverSupabaseUser = async (event: CompatibilityEvent): Promise<User> => {
+  const client = serverSupabaseClient(event)
+
+  if (!event.context._token) {
+    return
+  }
+
+  const { user: supabaseUser, error } = await client.auth.api.getUser(event.context._token)
+
+  event.context._user = error ? null : supabaseUser
+
+  return event.context._user
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,3 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "skipLibCheck": true,
-    "strict": false,
-    "allowJs": true,
-    "noEmit": true,
-    "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true,
-    "types": [
-      "node",
-      "@nuxt/kit"
-    ],
-    "paths": {
-      "#app": ["./node_modules/nuxt/dist/app"]
-    }
-  },
-  "include": [
-    "src"
-  ]
+  "extends": "./playground/.nuxt/tsconfig.json"
 }


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Because the vuejs context is not available we can't use "composables" on server routes. This feature add "services" that provide the exact same behaviour in server routes. You just have to call `serverSupabaseClient` instead of `useSupabaseClient`.


## Checklist:
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
