### PR TITLE
feat(server): support using a service role client

### DIFF
--- a/docs/pages/1.index.md
+++ b/docs/pages/1.index.md
@@ -63,11 +63,12 @@ export default defineNuxtConfig({
 })
 ```
 
-Lastly, add `SUPABASE_URL` and `SUPABASE_KEY` to the `.env`:
+Lastly, add `SUPABASE_URL`, `SUPABASE_KEY` and `SUPABASE_SERVICE_ROLE_KEY` to the `.env`:
 
 ```bash [.env]
 SUPABASE_URL="https://example.supabase.com"
 SUPABASE_KEY="<your_key>"
+SUPABASE_SERVICE_ROLE_KEY="<your_key>"
 ```
 
 ## Options
@@ -97,9 +98,17 @@ Environment variable `SUPABASE_URL` can be used to set `url`.
 
 - Default: `process.env.SUPABASE_KEY`
 
-The unique Supabase Key which is supplied when you create a new project in your project dashboard.
+The unique public Supabase key which is supplied when you create a new project in your project dashboard.
 
-Environment variable `SUPABASE_URL` can be used to set `key`.
+Environment variable `SUPABASE_KEY` can be used to set `key`.
+
+### `serviceRoleKey`
+
+- Default: `process.env.SUPABASE_SERVICE_ROLE_KEY`
+
+The unique secret Supabase Key which has the ability to bypass [Row Level Security](https://supabase.com/docs/guides/auth/row-level-security).
+
+Environment variable `SUPABASE_SERVICE_ROLE_KEY` can be used to set `serviceRoleKey`.
 
 ### `client`
 

--- a/docs/pages/2.usage.md
+++ b/docs/pages/2.usage.md
@@ -135,6 +135,25 @@ const { data: { librairies }} = await useFetch('/api/librairies', {
 })
 ```
 
+### `serverSupabaseServiceRoleClient`
+
+Similar to [serverSupabaseClient](/usage#serverSupabaseClient) but uses the service role key provided via the `SUPABASE_SERVICE_ROLE_KEY` environment variable. This client has the ability to bypass [RLS](https://supabase.com/docs/guides/auth/row-level-security)  and should only be used when you want to perform actions not authorized by the currently signed in user or when responding to webhooks where there is no active user session.
+
+Define your server route and just import the `serverSupabaseServiceRoleClient` from `#supabase/server`.
+
+```ts [server/api/librairies.ts]
+import { serverSupabaseServiceRoleClient } from '#supabase/server'
+
+export default eventHandler(async (event) => {
+  const client = serverSupabaseServiceRoleClient(event)
+
+  return await client.from("stripe_customers").create({
+    customer_id: "XYZ",
+    is_subscribed: true
+  })
+})
+```
+
 
 ### `serverSupabaseUser`
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -23,6 +23,15 @@ export interface ModuleOptions {
   key: string
 
   /**
+   * Supabase Service Role API key
+   * @default process.env.SUPABASE_SERVICE_ROLE_KEY
+   * @example '123456789'
+   * @type string
+   * @docs https://supabase.com/docs/reference/javascript/initializing#parameters
+   */
+  serviceRoleKey: string
+
+  /**
    * Supabase Client options
    * @default {}
    * @type object
@@ -56,6 +65,7 @@ export default defineNuxtModule<ModuleOptions>({
   defaults: {
     url: process.env.SUPABASE_URL as string,
     key: process.env.SUPABASE_KEY as string,
+    serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY as string,
     client: {},
     cookies: {
       name: 'sb',
@@ -79,12 +89,21 @@ export default defineNuxtModule<ModuleOptions>({
       console.warn('Missing `SUPABASE_KEY` in `.env`')
     }
 
+    if (!options.serviceRoleKey) {
+      // eslint-disable-next-line no-console
+      console.warn('Missing `SUPABASE_SERVICE_ROLE_KEY` in `.env`')
+    }
+
     // Default runtimeConfig
     nuxt.options.runtimeConfig.public.supabase = defu(nuxt.options.runtimeConfig.public.supabase, {
       url: options.url,
       key: options.key,
       client: options.client,
       cookies: options.cookies
+    })
+
+    nuxt.options.runtimeConfig.supabase = defu(nuxt.options.runtimeConfig.supabase, {
+      serviceRoleKey: options.serviceRoleKey
     })
 
     // Transpile runtime
@@ -119,6 +138,7 @@ export default defineNuxtModule<ModuleOptions>({
       getContents: () => [
         'declare module \'#supabase/server\' {',
         `  const serverSupabaseClient: typeof import('${resolve('./runtime/server/services')}').serverSupabaseClient`,
+        `  const serverSupabaseServiceRoleClient: typeof import('${resolve('./runtime/server/services')}').serverSupabaseServiceRoleClient`,
         `  const serverSupabaseUser: typeof import('${resolve('./runtime/server/services')}').serverSupabaseUser`,
         '}'
       ].join('\n')

--- a/src/runtime/server/services/index.ts
+++ b/src/runtime/server/services/index.ts
@@ -1,2 +1,2 @@
-export { serverSupabaseClient } from './serverSupabaseClient'
+export { serverSupabaseClient, serverSupabaseServiceRoleClient } from './serverSupabaseClient'
 export { serverSupabaseUser } from './serverSupabaseUser'

--- a/src/runtime/server/services/serverSupabaseClient.ts
+++ b/src/runtime/server/services/serverSupabaseClient.ts
@@ -2,19 +2,44 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import { CompatibilityEvent, useCookie } from 'h3'
 import { useRuntimeConfig } from '#imports'
 
+const makeClient = (key: string): SupabaseClient => {
+  const { supabase: { url, client: clientOptions } } = useRuntimeConfig().public
+
+  return createClient(url, key, clientOptions)
+}
+
 export const serverSupabaseClient = (event: CompatibilityEvent): SupabaseClient => {
-  const { supabase: { url, key, client: clientOptions, cookies: cookieOptions } } = useRuntimeConfig().public
+  const { supabase: { key, cookies: cookieOptions } } = useRuntimeConfig().public
 
   // No need to recreate client if exists in request context
-  if (!event.context._supabaseClient) {
-    const supabaseClient = createClient(url, key, clientOptions)
-    const token = useCookie(event, `${cookieOptions.name}-access-token`)
-
-    supabaseClient.auth.setAuth(token)
-
-    event.context._supabaseClient = supabaseClient
-    event.context._token = token
+  if (event.context._supabaseClient) {
+    return event.context._supabaseClient
   }
 
-  return event.context._supabaseClient
+  const client = makeClient(key)
+  const token = useCookie(event, `${cookieOptions.name}-access-token`)
+
+  client.auth.setAuth(token)
+  event.context._token = token
+  event.context._supabaseClient = client
+
+  return client
+}
+
+/**
+ * When using service role key we do not set auth token to avoid conflicts:
+ * https://github.com/supabase/supabase/issues/6277
+ */
+export const serverSupabaseServiceRoleClient = (event: CompatibilityEvent): SupabaseClient => {
+  const { supabase: { serviceRoleKey } } = useRuntimeConfig()
+
+  // No need to recreate client if exists in request context
+  if (event.context._supabaseServiceRoleClient) {
+    return event.context._supabaseServiceRoleClient
+  }
+
+  const client = makeClient(serviceRoleKey)
+  event.context._supabaseServiceRoleClient = client
+
+  return client
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR adds support for using the service role key provided by supabase in the server in order to bypass [RLS](https://supabase.com/docs/guides/auth/row-level-security).
Please let me know if I need to change something.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
added a new environment variable `SUPABASE_SERVICE_ROLE_KEY` and its corresponding module option `serviceRoleKey`
added new function `serverSupabaseServiceRoleClient` which uses the service role key (also did a small refactoring to `serverSupabaseClient`

resolves #30 


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
