### PR TITLE
docs(advanced): add onMounted hook to realtime example

### DIFF
--- a/docs/content/4.advanced.md
+++ b/docs/content/4.advanced.md
@@ -25,9 +25,11 @@ const { data: collaborators, refresh: refreshCollaborators } = await useAsyncDat
 })
 
 // Once page is mounted, listen to changes on the `collaborators` table and refresh collaborators when receiving event
-subscription = client.from('collaborators').on('*', () => {
-  refreshCollaborators()
-}).subscribe()
+onMounted(() => {
+  subscription = client.from('collaborators').on('*', () => {
+    refreshCollaborators()
+  }).subscribe()
+})
 
 // Don't forget to unsubscribe when user left the page
 onUnmounted(() => {


### PR DESCRIPTION
Added `onMounted` hook to the realtime example which is necessary to prevent the subscription from running on the server which causes issues.