### PR TITLE
docs: fix typos

### DIFF
--- a/docs/content/3.usage/1.composables.md
+++ b/docs/content/3.usage/1.composables.md
@@ -64,7 +64,7 @@ Here is an example of a fetch using the `select` method with Nuxt 3 [useAsyncDat
 <script setup lang="ts">
 const client = useSupabaseClient()
 
-const { data: restaurant } } = await useAsyncData('restaurant', async () => {
+const { data: restaurant } = await useAsyncData('restaurant', async () => {
   const { data } = await client.from('restaurants').select('name, location').eq('name', 'My Restaurant Name').single()
 
   return data

--- a/docs/content/4.advanced.md
+++ b/docs/content/4.advanced.md
@@ -40,7 +40,7 @@ onUnmounted(() => {
 
 ## Auth middleware
 
-You can protect your authenticated routes by creating a custom composable in your project, here is an example:
+You can protect your authenticated routes by creating a custom middleware in your project, here is an example:
 
 ```ts [middleware/auth.ts]
 export default defineNuxtRouteMiddleware((to, _from) => {


### PR DESCRIPTION
- removed an extra `}` in a code snippet
- replaced *composable* by *middleware*