### PR TITLE
chore(logger): reference `nuxt.config.ts` instead of `nuxt.config.js`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -167,7 +167,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Warn if the url isn't set.
     if (!finalUrl) {
-      logger.warn('Missing supabase url, set it either in `nuxt.config.js` or via env variable')
+      logger.warn('Missing supabase url, set it either in `nuxt.config.ts` or via env variable')
     }
     else {
       // Use the default storage key as defined by the supabase-js client if no cookiePrefix is set.
@@ -179,7 +179,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Warn if the key isn't set.
     if (!nuxt.options.runtimeConfig.public.supabase.key) {
-      logger.warn('Missing supabase anon key, set it either in `nuxt.config.js` or via env variable')
+      logger.warn('Missing supabase anon key, set it either in `nuxt.config.ts` or via env variable')
     }
 
     // Warn for deprecated features.


### PR DESCRIPTION
## Types of changes
* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR updates developer-facing warning messages to reference the correct Nuxt config filename:

* In module setup warnings for missing Supabase URL and anon key, change:
  * `nuxt.config.js` -> `nuxt.config.ts`

**Why**: Nuxt 3/4 projects default to TypeScript config (`nuxt.config.ts`). The previous message was misleading for TS users and could cause confusion during setup.

No runtime logic changes; DX-only copy correction.

## Checklist:

* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes (if not applicable, please state why)