### PR TITLE
fix: restore session before auth middleware in SPA mode

### DIFF
--- a/src/runtime/plugins/supabase.client.ts
+++ b/src/runtime/plugins/supabase.client.ts
@@ -44,6 +44,16 @@ export default defineNuxtPlugin({
     const currentSession = useSupabaseSession()
     const currentUser = useSupabaseUser()
 
+    // In SPA mode, restore session from storage before auth middleware runs.
+    // This prevents a race condition where middleware checks session before it's hydrated.
+    // See: https://github.com/nuxt-modules/supabase/issues/496
+    if (!useSsrCookies) {
+      const { data } = await client.auth.getSession()
+      if (data.session) {
+        currentSession.value = data.session
+      }
+    }
+
     // Populate user before each page load to ensure the user state is correctly set before the page is rendered
     nuxtApp.hook('page:start', async () => {
       const { data } = await client.auth.getClaims()


### PR DESCRIPTION
## Summary                                                                                                                     
                                                                                                                                 
  In SPA mode (`useSsrCookies: false`), there's a race condition where the `auth-redirect` middleware checks                     
  `useSupabaseSession()` before the session is hydrated from localStorage. This causes authenticated users to be incorrectly     
  redirected to the login page on direct navigation or page reload.                                                              
                                                                                                                                 
  ## The Problem                                                                                                                 
                                                                                                                                 
  1. User is authenticated with a valid session in localStorage                                                                  
  2. User navigates directly to a protected route (or reloads the page)                                                          
  3. The `auth-redirect` middleware runs and checks `useSupabaseSession().value`                                                 
  4. Session state is still `null` because `onAuthStateChange` hasn't fired yet                                                  
  5. User gets redirected to `/login`                                                                                            
  6. `onAuthStateChange` fires with the valid session                                                                            
  7. Login page detects session and redirects back                                                                               
                                                                                                                                 
  This creates a flash/redirect loop that degrades UX and can break deep linking.                                                
                                                                                                                                 
  ## The Fix                                                                                                                     
                                                                                                                                 
  Explicitly call `getSession()` and populate the session state before the plugin setup completes. This ensures the session is   
  available when middleware runs.                                                                                                
                                                                                                                                 
  The fix only applies when `useSsrCookies` is `false` (SPA mode), since SSR mode uses cookies which are available synchronously.
                                                                                                                                 
  ## Test Plan                                                                                                                   
                                                                                                                                 
  - [x] Tested with `ssr: false` and `useSsrCookies: false` configuration                                                        
  - [x] Direct navigation to protected routes works without redirect flash                                                       
  - [x] Page reload maintains authentication state                                                                               
  - [x] Logout still works correctly                                                                                             
  - [x] Login flow still works correctly                                                                                         
                                                                                                                                 
  Fixes #496                                                                                                                     
                                                                                                                                 
  🤖 Generated with [Claude Code](https://claude.ai/code)   