### PR TITLE
Add Vercel x Supabase ENV Variable names to coalesce key and secretKey

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -130,9 +130,14 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {
     url: process.env.SUPABASE_URL as string,
-    key: process.env.SUPABASE_KEY as string,
+    key: (process.env.SUPABASE_KEY
+      ?? process.env.SUPABASE_PUBLISHABLE_KEY
+      ?? process.env.NUXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+      ?? process.env.SUPABASE_ANON_KEY
+      ?? process.env.NUXT_PUBLIC_SUPABASE_ANON_KEY) as string,
     serviceKey: process.env.SUPABASE_SERVICE_KEY as string,
-    secretKey: process.env.SUPABASE_SECRET_KEY as string,
+    secretKey: (process.env.SUPABASE_SECRET_KEY
+      ?? process.env.SUPABASE_SERVICE_ROLE_KEY) as string,
     redirect: true,
     redirectOptions: {
       login: '/login',


### PR DESCRIPTION
Vercel x Supabase integration automatically synchronizes environment variables. Currently, Nuxt Supabase Module does not look for the secret or publishable key in the variables the integration uses. 

Here is the list of ENV vars Supabase syncs with Vercel:

NEXT_PUBLIC_SUPABASE_ANON_KEY
NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
NEXT_PUBLIC_SUPABASE_URL
NUXT_PUBLIC_SUPABASE_ANON_KEY
NUXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
POSTGRES_DATABASE
POSTGRES_HOST
POSTGRES_PASSWORD
POSTGRES_PRISMA_URL
POSTGRES_URL
POSTGRES_URL_NON_POOLING
POSTGRES_USER
NEXT_PUBLIC_SUPABASE_ANON_KEY
SUPABASE_JWT_SECRET
NUXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
SUPABASE_SECRET_KEY
SUPABASE_SERVICE_ROLE_KEY
NEXT_PUBLIC_SUPABASE_URL

I have added coalescing for the relevant secret and public keys like so:
```typescript
key: SUPABASE_KEY ?? SUPABASE_PUBLISHABLE_KEY ?? NUXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? SUPABASE_ANON_KEY ?? NUXT_PUBLIC_SUPABASE_ANON_KEY,
secretKey: SUPABASE_SECRET_KEY  ?? SUPABASE_SERVICE_ROLE_KEY,
```

solves #302 
solves #480 