### PR TITLE
Fix output path for Supabase TypeScript types

### DIFF
--- a/docs/content/1.getting-started/1.introduction.md
+++ b/docs/content/1.getting-started/1.introduction.md
@@ -161,10 +161,10 @@ The path for the generated Supabase TypeScript definitions. The database definit
 
 ```bash
 ## Generate types from live database
-supabase gen types --lang=typescript --project-id YourProjectId > types/database.types.ts
+supabase gen types --lang=typescript --project-id YourProjectId > app/types/database.types.ts
 
 ## Generate types when using local environment
-supabase gen types --lang=typescript --local > types/database.types.ts
+supabase gen types --lang=typescript --local > app/types/database.types.ts
 ```
 
 Set to `false` to disable.


### PR DESCRIPTION
Update the output path for generated TypeScript definitions to 'app/types/database.types.ts'.
