### PR TITLE
fix(server): forward auth error status code to createError

### DIFF
--- a/src/runtime/server/services/serverSupabaseSession.ts
+++ b/src/runtime/server/services/serverSupabaseSession.ts
@@ -8,7 +8,10 @@ export const serverSupabaseSession = async (event: H3Event): Promise<Omit<Sessio
 
   const { data: { session }, error } = await client.auth.getSession()
   if (error) {
-    throw createError({ statusMessage: error?.message })
+    throw createError({
+      statusCode: error.status ?? 500,
+      statusMessage: error.message,
+    })
   }
 
   // @ts-expect-error we need to delete user from the session object here to suppress the warning coming from GoTrueClient

--- a/src/runtime/server/services/serverSupabaseUser.ts
+++ b/src/runtime/server/services/serverSupabaseUser.ts
@@ -8,7 +8,10 @@ export const serverSupabaseUser = async (event: H3Event): Promise<JwtPayload | n
 
   const { data, error } = await client.auth.getClaims()
   if (error) {
-    throw createError({ statusMessage: error?.message })
+    throw createError({
+      statusCode: error.status ?? 500,
+      statusMessage: error.message,
+    })
   }
 
   return data?.claims ?? null


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

`serverSupabaseUser` and `serverSupabaseSession` currently rethrow Supabase auth errors as plain `createError({ statusMessage })` calls, which defaults the HTTP status to 500. This swallows the actual status that the underlying `AuthError` already carries.

For example, a failed JWT signature verification raises `AuthInvalidJwtError` with `status: 400`, a failure inside `getClaims()` while fetching JWKS surfaces the upstream `status` (often 5xx from the Supabase backend), and `AuthSessionMissingError` exposes `status: 400`. With the current code all of those reach the client as a generic 500, which makes it hard to distinguish a legitimate auth failure from a real server fault and noises up error monitoring with false 5xx alerts.

This change forwards `error.status` when present and falls back to 500 if the error object did not include one (only happens for `AuthUnknownError` and friends). Behavior is unchanged for the success path and for the no-session-no-error path that `getClaims()` already returns null for after the move to JWT signing keys in v2.0.6.

Note: this does not address #388, which is about prerender-time `serverSupabaseUser` throwing on missing sessions. That path no longer throws in v2.x since the migration from `getUser()` to `getClaims()`.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (no unit tests exist for these services currently and the change is a two-line passthrough).